### PR TITLE
Bump imgui version from v1.79 to v1.84.1.

### DIFF
--- a/examples/Direct3D10Widget_ImGui/CMakeLists.txt
+++ b/examples/Direct3D10Widget_ImGui/CMakeLists.txt
@@ -21,12 +21,12 @@ set(WIDGETS_CXX_FILES
     ${QTDIRECT3D_WIDGETS_DIR}/QDirect3D10Widget/ImGui/QDirect3D10Widget.cpp
 )
 set(IMGUI_IMPL_HEADERS_CXX_FILES
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_dx10.h
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_win32.h
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_dx10.h
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_win32.h
 )
 set(IMGUI_IMPL_SOURCES_CXX_FILES
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_dx10.cpp
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_win32.cpp
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_dx10.cpp
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_win32.cpp
 )
 set(IMGUI_FILES
     ${IMGUI_HEADERS_CXX_FILES}
@@ -66,7 +66,7 @@ source_group("ImGui" FILES
     ${IMGUI_HEADERS_CXX_FILES}
     ${IMGUI_SOURCES_CXX_FILES}
 )
-source_group("ImGui\\Impl" FILES
+source_group("ImGui\\Backend" FILES
     ${IMGUI_IMPL_HEADERS_CXX_FILES}
     ${IMGUI_IMPL_SOURCES_CXX_FILES}
 )

--- a/examples/Direct3D10Widget_ImGui/QtDirect3D10_ImGui.vcxproj
+++ b/examples/Direct3D10Widget_ImGui/QtDirect3D10_ImGui.vcxproj
@@ -142,33 +142,34 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D10Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D10Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D10Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D10Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D10Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D10Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D10Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D10Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <QtUic Include="MainWindow.ui" />
     <QtMoc Include="MainWindow.h" />
     <ClCompile Include="..\..\source\QDirect3D10Widget\ImGui\QDirect3D10Widget.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_dx10.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_dx10.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_demo.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_draw.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\imgui_tables.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_widgets.cpp" />
     <ClCompile Include="MainWindow.cpp" />
     <ClCompile Include="main.cpp" />
@@ -177,8 +178,8 @@
     <QtMoc Include="..\..\source\QDirect3D10Widget\ImGui\QDirect3D10Widget.h">
       <QtMocDir>$(IntDir)moc</QtMocDir>
     </QtMoc>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_dx10.h" />
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.h" />
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_dx10.h" />
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imconfig.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imgui.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imgui_internal.h" />

--- a/examples/Direct3D10Widget_ImGui/QtDirect3D10_ImGui.vcxproj.filters
+++ b/examples/Direct3D10Widget_ImGui/QtDirect3D10_ImGui.vcxproj.filters
@@ -13,15 +13,15 @@
     <Filter Include="ImGui">
       <UniqueIdentifier>{5e0c552a-15b1-47d6-813e-456c69d93997}</UniqueIdentifier>
     </Filter>
-    <Filter Include="ImGui\Impl">
-      <UniqueIdentifier>{9032cf27-f8a0-4de8-9e21-bc4d2321c257}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Widgets">
       <UniqueIdentifier>{d4ead10b-5d32-458f-a5fd-5c3820fdaf37}</UniqueIdentifier>
     </Filter>
     <Filter Include="Resources">
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="ImGui\Backend">
+      <UniqueIdentifier>{9032cf27-f8a0-4de8-9e21-bc4d2321c257}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -42,11 +42,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_dx10.cpp">
-      <Filter>ImGui\Impl</Filter>
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_dx10.cpp">
+      <Filter>ImGui\Backend</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.cpp">
-      <Filter>ImGui\Impl</Filter>
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.cpp">
+      <Filter>ImGui\Backend</Filter>
     </ClCompile>
     <ClCompile Include="..\..\thirdparty\imgui\imgui.cpp">
       <Filter>ImGui</Filter>
@@ -57,6 +57,9 @@
     <ClCompile Include="..\..\thirdparty\imgui\imgui_draw.cpp">
       <Filter>ImGui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\thirdparty\imgui\imgui_tables.cpp">
+      <Filter>ImGui</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\thirdparty\imgui\imgui_widgets.cpp">
       <Filter>ImGui</Filter>
     </ClCompile>
@@ -65,11 +68,11 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_dx10.h">
-      <Filter>ImGui\Impl</Filter>
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_dx10.h">
+      <Filter>ImGui\Backend</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.h">
-      <Filter>ImGui\Impl</Filter>
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.h">
+      <Filter>ImGui\Backend</Filter>
     </ClInclude>
     <ClInclude Include="..\..\thirdparty\imgui\imconfig.h">
       <Filter>ImGui</Filter>

--- a/examples/Direct3D11Widget_ImGui/CMakeLists.txt
+++ b/examples/Direct3D11Widget_ImGui/CMakeLists.txt
@@ -21,12 +21,12 @@ set(WIDGETS_CXX_FILES
     ${QTDIRECT3D_WIDGETS_DIR}/QDirect3D11Widget/ImGui/QDirect3D11Widget.cpp
 )
 set(IMGUI_IMPL_HEADERS_CXX_FILES
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_dx11.h
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_win32.h
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_dx11.h
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_win32.h
 )
 set(IMGUI_IMPL_SOURCES_CXX_FILES
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_dx11.cpp
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_win32.cpp
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_dx11.cpp
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_win32.cpp
 )
 set(IMGUI_FILES
     ${IMGUI_HEADERS_CXX_FILES}
@@ -66,7 +66,7 @@ source_group("ImGui" FILES
     ${IMGUI_HEADERS_CXX_FILES}
     ${IMGUI_SOURCES_CXX_FILES}
 )
-source_group("ImGui\\Impl" FILES
+source_group("ImGui\\Backend" FILES
     ${IMGUI_IMPL_HEADERS_CXX_FILES}
     ${IMGUI_IMPL_SOURCES_CXX_FILES}
 )

--- a/examples/Direct3D11Widget_ImGui/QtDirect3D11_ImGui.vcxproj
+++ b/examples/Direct3D11Widget_ImGui/QtDirect3D11_ImGui.vcxproj
@@ -142,33 +142,34 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D11Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D11Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D11Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D11Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D11Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D11Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D11Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D11Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <QtUic Include="MainWindow.ui" />
     <QtMoc Include="MainWindow.h" />
     <ClCompile Include="..\..\source\QDirect3D11Widget\ImGui\QDirect3D11Widget.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_dx11.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_dx11.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_demo.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_draw.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\imgui_tables.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_widgets.cpp" />
     <ClCompile Include="MainWindow.cpp" />
     <ClCompile Include="main.cpp" />
@@ -177,8 +178,8 @@
     <QtMoc Include="..\..\source\QDirect3D11Widget\ImGui\QDirect3D11Widget.h">
       <QtMocDir>$(IntDir)moc</QtMocDir>
     </QtMoc>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_dx11.h" />
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.h" />
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_dx11.h" />
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imconfig.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imgui.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imgui_internal.h" />

--- a/examples/Direct3D11Widget_ImGui/QtDirect3D11_ImGui.vcxproj.filters
+++ b/examples/Direct3D11Widget_ImGui/QtDirect3D11_ImGui.vcxproj.filters
@@ -13,15 +13,15 @@
     <Filter Include="ImGui">
       <UniqueIdentifier>{5e0c552a-15b1-47d6-813e-456c69d93997}</UniqueIdentifier>
     </Filter>
-    <Filter Include="ImGui\Impl">
-      <UniqueIdentifier>{9032cf27-f8a0-4de8-9e21-bc4d2321c257}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Widgets">
       <UniqueIdentifier>{d4ead10b-5d32-458f-a5fd-5c3820fdaf37}</UniqueIdentifier>
     </Filter>
     <Filter Include="Resources">
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="ImGui\Backend">
+      <UniqueIdentifier>{9032cf27-f8a0-4de8-9e21-bc4d2321c257}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -42,11 +42,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_dx11.cpp">
-      <Filter>ImGui\Impl</Filter>
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_dx11.cpp">
+      <Filter>ImGui\Backend</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.cpp">
-      <Filter>ImGui\Impl</Filter>
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.cpp">
+      <Filter>ImGui\Backend</Filter>
     </ClCompile>
     <ClCompile Include="..\..\thirdparty\imgui\imgui.cpp">
       <Filter>ImGui</Filter>
@@ -57,6 +57,9 @@
     <ClCompile Include="..\..\thirdparty\imgui\imgui_draw.cpp">
       <Filter>ImGui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\thirdparty\imgui\imgui_tables.cpp">
+      <Filter>ImGui</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\thirdparty\imgui\imgui_widgets.cpp">
       <Filter>ImGui</Filter>
     </ClCompile>
@@ -65,11 +68,11 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_dx11.h">
-      <Filter>ImGui\Impl</Filter>
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_dx11.h">
+      <Filter>ImGui\Backend</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.h">
-      <Filter>ImGui\Impl</Filter>
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.h">
+      <Filter>ImGui\Backend</Filter>
     </ClInclude>
     <ClInclude Include="..\..\thirdparty\imgui\imconfig.h">
       <Filter>ImGui</Filter>

--- a/examples/Direct3D12Widget_ImGui/CMakeLists.txt
+++ b/examples/Direct3D12Widget_ImGui/CMakeLists.txt
@@ -27,12 +27,12 @@ set(WIDGETS_CXX_FILES
     ${QTDIRECT3D_WIDGETS_DIR}/QDirect3D12Widget/ImGui/QDirect3D12Widget.cpp
 )
 set(IMGUI_IMPL_HEADERS_CXX_FILES
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_dx12.h
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_win32.h
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_dx12.h
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_win32.h
 )
 set(IMGUI_IMPL_SOURCES_CXX_FILES
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_dx12.cpp
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_win32.cpp
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_dx12.cpp
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_win32.cpp
 )
 set(IMGUI_FILES
     ${IMGUI_HEADERS_CXX_FILES}
@@ -72,7 +72,7 @@ source_group("ImGui" FILES
     ${IMGUI_HEADERS_CXX_FILES}
     ${IMGUI_SOURCES_CXX_FILES}
 )
-source_group("ImGui\\Impl" FILES
+source_group("ImGui\\Backend" FILES
     ${IMGUI_IMPL_HEADERS_CXX_FILES}
     ${IMGUI_IMPL_SOURCES_CXX_FILES}
 )

--- a/examples/Direct3D12Widget_ImGui/QtDirect3D12_ImGui.vcxproj
+++ b/examples/Direct3D12Widget_ImGui/QtDirect3D12_ImGui.vcxproj
@@ -142,25 +142,25 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D12Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D12Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ImTextureID=ImU64;$(Qt_DEFINES_);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D12Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D12Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ImTextureID=ImU64;$(Qt_DEFINES_);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D12Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D12Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ImTextureID=ImU64;$(Qt_DEFINES_);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D12Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D12Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>ImTextureID=ImU64;$(Qt_DEFINES_);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -168,11 +168,12 @@
     <QtUic Include="MainWindow.ui" />
     <QtMoc Include="MainWindow.h" />
     <ClCompile Include="..\..\source\QDirect3D12Widget\ImGui\QDirect3D12Widget.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_dx12.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_dx12.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_demo.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_draw.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\imgui_tables.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_widgets.cpp" />
     <ClCompile Include="MainWindow.cpp" />
     <ClCompile Include="main.cpp" />
@@ -181,8 +182,8 @@
     <QtMoc Include="..\..\source\QDirect3D12Widget\ImGui\QDirect3D12Widget.h">
       <QtMocDir>$(IntDir)moc</QtMocDir>
     </QtMoc>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_dx12.h" />
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.h" />
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_dx12.h" />
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imconfig.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imgui.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imgui_internal.h" />

--- a/examples/Direct3D12Widget_ImGui/QtDirect3D12_ImGui.vcxproj.filters
+++ b/examples/Direct3D12Widget_ImGui/QtDirect3D12_ImGui.vcxproj.filters
@@ -8,15 +8,15 @@
     <Filter Include="ImGui">
       <UniqueIdentifier>{5e0c552a-15b1-47d6-813e-456c69d93997}</UniqueIdentifier>
     </Filter>
-    <Filter Include="ImGui\Impl">
-      <UniqueIdentifier>{9032cf27-f8a0-4de8-9e21-bc4d2321c257}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Widgets">
       <UniqueIdentifier>{d4ead10b-5d32-458f-a5fd-5c3820fdaf37}</UniqueIdentifier>
     </Filter>
     <Filter Include="Resources">
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="ImGui\Backend">
+      <UniqueIdentifier>{9032cf27-f8a0-4de8-9e21-bc4d2321c257}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -37,11 +37,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_dx12.cpp">
-      <Filter>ImGui\Impl</Filter>
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_dx12.cpp">
+      <Filter>ImGui\Backend</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.cpp">
-      <Filter>ImGui\Impl</Filter>
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.cpp">
+      <Filter>ImGui\Backend</Filter>
     </ClCompile>
     <ClCompile Include="..\..\thirdparty\imgui\imgui.cpp">
       <Filter>ImGui</Filter>
@@ -52,6 +52,9 @@
     <ClCompile Include="..\..\thirdparty\imgui\imgui_draw.cpp">
       <Filter>ImGui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\thirdparty\imgui\imgui_tables.cpp">
+      <Filter>ImGui</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\thirdparty\imgui\imgui_widgets.cpp">
       <Filter>ImGui</Filter>
     </ClCompile>
@@ -60,11 +63,11 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_dx12.h">
-      <Filter>ImGui\Impl</Filter>
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_dx12.h">
+      <Filter>ImGui\Backend</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.h">
-      <Filter>ImGui\Impl</Filter>
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.h">
+      <Filter>ImGui\Backend</Filter>
     </ClInclude>
     <ClInclude Include="..\..\thirdparty\imgui\imconfig.h">
       <Filter>ImGui</Filter>

--- a/examples/Direct3D9Widget_ImGui/CMakeLists.txt
+++ b/examples/Direct3D9Widget_ImGui/CMakeLists.txt
@@ -22,12 +22,12 @@ set(WIDGETS_CXX_FILES
     ${QTDIRECT3D_WIDGETS_DIR}/QDirect3D9Widget/ImGui/QDirect3D9Widget.cpp
 )
 set(IMGUI_IMPL_HEADERS_CXX_FILES
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_dx9.h
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_win32.h
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_dx9.h
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_win32.h
 )
 set(IMGUI_IMPL_SOURCES_CXX_FILES
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_dx9.cpp
-    ${IMGUI_ROOT_DIR}/examples/imgui_impl_win32.cpp
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_dx9.cpp
+    ${IMGUI_ROOT_DIR}/backends/imgui_impl_win32.cpp
 )
 set(IMGUI_FILES
     ${IMGUI_HEADERS_CXX_FILES}
@@ -67,7 +67,7 @@ source_group("ImGui" FILES
     ${IMGUI_HEADERS_CXX_FILES}
     ${IMGUI_SOURCES_CXX_FILES}
 )
-source_group("ImGui\\Impl" FILES
+source_group("ImGui\\Backend" FILES
     ${IMGUI_IMPL_HEADERS_CXX_FILES}
     ${IMGUI_IMPL_SOURCES_CXX_FILES}
 )

--- a/examples/Direct3D9Widget_ImGui/QtDirect3D9_ImGui.vcxproj
+++ b/examples/Direct3D9Widget_ImGui/QtDirect3D9_ImGui.vcxproj
@@ -142,33 +142,34 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D9Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D9Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D9Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D9Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D9Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D9Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\source\QDirect3D9Widget\ImGui;..\..\thirdparty\imgui;..\..\thirdparty\imgui\examples;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\source\QDirect3D9Widget\ImGui;..\..\thirdparty\imgui;$(Qt_INCLUDEPATH_);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <QtUic Include="MainWindow.ui" />
     <QtMoc Include="MainWindow.h" />
     <ClCompile Include="..\..\source\QDirect3D9Widget\ImGui\QDirect3D9Widget.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_dx9.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_dx9.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_demo.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_draw.cpp" />
+    <ClCompile Include="..\..\thirdparty\imgui\imgui_tables.cpp" />
     <ClCompile Include="..\..\thirdparty\imgui\imgui_widgets.cpp" />
     <ClCompile Include="MainWindow.cpp" />
     <ClCompile Include="main.cpp" />
@@ -177,8 +178,8 @@
     <QtMoc Include="..\..\source\QDirect3D9Widget\ImGui\QDirect3D9Widget.h">
       <QtMocDir>$(IntDir)moc</QtMocDir>
     </QtMoc>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_dx9.h" />
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.h" />
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_dx9.h" />
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imconfig.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imgui.h" />
     <ClInclude Include="..\..\thirdparty\imgui\imgui_internal.h" />

--- a/examples/Direct3D9Widget_ImGui/QtDirect3D9_ImGui.vcxproj.filters
+++ b/examples/Direct3D9Widget_ImGui/QtDirect3D9_ImGui.vcxproj.filters
@@ -13,15 +13,15 @@
     <Filter Include="ImGui">
       <UniqueIdentifier>{5e0c552a-15b1-47d6-813e-456c69d93997}</UniqueIdentifier>
     </Filter>
-    <Filter Include="ImGui\Impl">
-      <UniqueIdentifier>{9032cf27-f8a0-4de8-9e21-bc4d2321c257}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Widgets">
       <UniqueIdentifier>{d4ead10b-5d32-458f-a5fd-5c3820fdaf37}</UniqueIdentifier>
     </Filter>
     <Filter Include="Resources">
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="ImGui\Backend">
+      <UniqueIdentifier>{9032cf27-f8a0-4de8-9e21-bc4d2321c257}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -42,11 +42,11 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_dx9.cpp">
-      <Filter>ImGui\Impl</Filter>
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_dx9.cpp">
+      <Filter>ImGui\Backend</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.cpp">
-      <Filter>ImGui\Impl</Filter>
+    <ClCompile Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.cpp">
+      <Filter>ImGui\Backend</Filter>
     </ClCompile>
     <ClCompile Include="..\..\thirdparty\imgui\imgui.cpp">
       <Filter>ImGui</Filter>
@@ -57,6 +57,9 @@
     <ClCompile Include="..\..\thirdparty\imgui\imgui_draw.cpp">
       <Filter>ImGui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\thirdparty\imgui\imgui_tables.cpp">
+      <Filter>ImGui</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\thirdparty\imgui\imgui_widgets.cpp">
       <Filter>ImGui</Filter>
     </ClCompile>
@@ -65,11 +68,11 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_dx9.h">
-      <Filter>ImGui\Impl</Filter>
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_dx9.h">
+      <Filter>ImGui\Backend</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\thirdparty\imgui\examples\imgui_impl_win32.h">
-      <Filter>ImGui\Impl</Filter>
+    <ClInclude Include="..\..\thirdparty\imgui\backends\imgui_impl_win32.h">
+      <Filter>ImGui\Backend</Filter>
     </ClInclude>
     <ClInclude Include="..\..\thirdparty\imgui\imconfig.h">
       <Filter>ImGui</Filter>

--- a/source/QDirect3D10Widget/ImGui/QDirect3D10Widget.cpp
+++ b/source/QDirect3D10Widget/ImGui/QDirect3D10Widget.cpp
@@ -10,8 +10,8 @@
 #include <QWheelEvent>
 
 #include "imgui.h"
-#include "imgui_impl_dx10.h"
-#include "imgui_impl_win32.h"
+#include "backends/imgui_impl_dx10.h"
+#include "backends/imgui_impl_win32.h"
 
 constexpr int FPS_LIMIT    = 60.0f;
 constexpr int MS_PER_FRAME = (int)((1.0f / FPS_LIMIT) * 1000.0f);
@@ -220,7 +220,7 @@ void QDirect3D10Widget::resetEnvironment()
 
 void QDirect3D10Widget::wheelEvent(QWheelEvent * event)
 {
-    if (!ImGui::IsAnyWindowHovered() && event->angleDelta().x() == 0)
+    if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && event->angleDelta().x() == 0)
     {
         // TODO: Update your camera position based on the delta value.
     }
@@ -286,14 +286,14 @@ bool QDirect3D10Widget::event(QEvent * event)
             emit keyPressed((QKeyEvent *)event);
             break;
         case QEvent::MouseMove:
-            if (!ImGui::IsAnyWindowHovered()) emit mouseMoved((QMouseEvent *)event);
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) emit mouseMoved((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonPress:
-            if (!ImGui::IsAnyWindowHovered() && !ImGui::IsAnyWindowFocused())
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseClicked((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonRelease:
-            if (!ImGui::IsAnyWindowHovered() && !ImGui::IsAnyWindowFocused())
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseReleased((QMouseEvent *)event);
             break;
     }

--- a/source/QDirect3D10Widget/ImGui/QDirect3D10Widget.cpp
+++ b/source/QDirect3D10Widget/ImGui/QDirect3D10Widget.cpp
@@ -286,14 +286,17 @@ bool QDirect3D10Widget::event(QEvent * event)
             emit keyPressed((QKeyEvent *)event);
             break;
         case QEvent::MouseMove:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) emit mouseMoved((QMouseEvent *)event);
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
+                emit mouseMoved((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonPress:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) &&
+                !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseClicked((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonRelease:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) &&
+                !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseReleased((QMouseEvent *)event);
             break;
     }

--- a/source/QDirect3D11Widget/ImGui/QDirect3D11Widget.cpp
+++ b/source/QDirect3D11Widget/ImGui/QDirect3D11Widget.cpp
@@ -10,8 +10,8 @@
 #include <QWheelEvent>
 
 #include "imgui.h"
-#include "imgui_impl_dx11.h"
-#include "imgui_impl_win32.h"
+#include "backends/imgui_impl_dx11.h"
+#include "backends/imgui_impl_win32.h"
 
 constexpr int FPS_LIMIT    = 60.0f;
 constexpr int MS_PER_FRAME = (int)((1.0f / FPS_LIMIT) * 1000.0f);
@@ -227,7 +227,7 @@ void QDirect3D11Widget::resetEnvironment()
 
 void QDirect3D11Widget::wheelEvent(QWheelEvent * event)
 {
-    if (!ImGui::IsAnyWindowHovered() && event->angleDelta().x() == 0)
+    if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && event->angleDelta().x() == 0)
     {
         // TODO: Update your camera position based on the delta value.
     }
@@ -293,14 +293,14 @@ bool QDirect3D11Widget::event(QEvent * event)
             emit keyPressed((QKeyEvent *)event);
             break;
         case QEvent::MouseMove:
-            if (!ImGui::IsAnyWindowHovered()) emit mouseMoved((QMouseEvent *)event);
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) emit mouseMoved((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonPress:
-            if (!ImGui::IsAnyWindowHovered() && !ImGui::IsAnyWindowFocused())
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseClicked((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonRelease:
-            if (!ImGui::IsAnyWindowHovered() && !ImGui::IsAnyWindowFocused())
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseReleased((QMouseEvent *)event);
             break;
     }

--- a/source/QDirect3D11Widget/ImGui/QDirect3D11Widget.cpp
+++ b/source/QDirect3D11Widget/ImGui/QDirect3D11Widget.cpp
@@ -293,14 +293,17 @@ bool QDirect3D11Widget::event(QEvent * event)
             emit keyPressed((QKeyEvent *)event);
             break;
         case QEvent::MouseMove:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) emit mouseMoved((QMouseEvent *)event);
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
+                emit mouseMoved((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonPress:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) &&
+                !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseClicked((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonRelease:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) &&
+                !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseReleased((QMouseEvent *)event);
             break;
     }

--- a/source/QDirect3D12Widget/ImGui/QDirect3D12Widget.cpp
+++ b/source/QDirect3D12Widget/ImGui/QDirect3D12Widget.cpp
@@ -549,14 +549,17 @@ bool QDirect3D12Widget::event(QEvent * event)
             emit keyPressed((QKeyEvent *)event);
             break;
         case QEvent::MouseMove:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) emit mouseMoved((QMouseEvent *)event);
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
+                emit mouseMoved((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonPress:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) &&
+                !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseClicked((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonRelease:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) &&
+                !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseReleased((QMouseEvent *)event);
             break;
     }

--- a/source/QDirect3D12Widget/ImGui/QDirect3D12Widget.cpp
+++ b/source/QDirect3D12Widget/ImGui/QDirect3D12Widget.cpp
@@ -12,8 +12,8 @@
 #include <QWheelEvent>
 
 #include "imgui.h"
-#include "imgui_impl_dx12.h"
-#include "imgui_impl_win32.h"
+#include "backends/imgui_impl_dx12.h"
+#include "backends/imgui_impl_win32.h"
 
 using Microsoft::WRL::ComPtr;
 
@@ -483,7 +483,7 @@ void QDirect3D12Widget::resetEnvironment()
 
 void QDirect3D12Widget::wheelEvent(QWheelEvent * event)
 {
-    if (!ImGui::IsAnyWindowHovered() && event->angleDelta().x() == 0)
+    if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && event->angleDelta().x() == 0)
     {
         // TODO: Update your camera position based on the delta value.
     }
@@ -549,14 +549,14 @@ bool QDirect3D12Widget::event(QEvent * event)
             emit keyPressed((QKeyEvent *)event);
             break;
         case QEvent::MouseMove:
-            if (!ImGui::IsAnyWindowHovered()) emit mouseMoved((QMouseEvent *)event);
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) emit mouseMoved((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonPress:
-            if (!ImGui::IsAnyWindowHovered() && !ImGui::IsAnyWindowFocused())
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseClicked((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonRelease:
-            if (!ImGui::IsAnyWindowHovered() && !ImGui::IsAnyWindowFocused())
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseReleased((QMouseEvent *)event);
             break;
     }

--- a/source/QDirect3D9Widget/ImGui/QDirect3D9Widget.cpp
+++ b/source/QDirect3D9Widget/ImGui/QDirect3D9Widget.cpp
@@ -10,8 +10,8 @@
 #include <QWheelEvent>
 
 #include "imgui.h"
-#include "imgui_impl_dx9.h"
-#include "imgui_impl_win32.h"
+#include "backends/imgui_impl_dx9.h"
+#include "backends/imgui_impl_win32.h"
 
 constexpr int FPS_LIMIT    = 60.0f;
 constexpr int MS_PER_FRAME = (int)((1.0f / FPS_LIMIT) * 1000.0f);
@@ -230,7 +230,7 @@ void QDirect3D9Widget::resetEnvironment()
 
 void QDirect3D9Widget::wheelEvent(QWheelEvent * event)
 {
-    if (!ImGui::IsAnyWindowHovered() && event->angleDelta().x() == 0)
+    if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && event->angleDelta().x() == 0)
     {
         // TODO: Update your camera position based on the delta value.
     }
@@ -296,14 +296,14 @@ bool QDirect3D9Widget::event(QEvent * event)
             emit keyPressed((QKeyEvent *)event);
             break;
         case QEvent::MouseMove:
-            if (!ImGui::IsAnyWindowHovered()) emit mouseMoved((QMouseEvent *)event);
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) emit mouseMoved((QMouseEvent*)event);
             break;
         case QEvent::MouseButtonPress:
-            if (!ImGui::IsAnyWindowHovered() && !ImGui::IsAnyWindowFocused())
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseClicked((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonRelease:
-            if (!ImGui::IsAnyWindowHovered() && !ImGui::IsAnyWindowFocused())
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseReleased((QMouseEvent *)event);
             break;
     }

--- a/source/QDirect3D9Widget/ImGui/QDirect3D9Widget.cpp
+++ b/source/QDirect3D9Widget/ImGui/QDirect3D9Widget.cpp
@@ -296,14 +296,17 @@ bool QDirect3D9Widget::event(QEvent * event)
             emit keyPressed((QKeyEvent *)event);
             break;
         case QEvent::MouseMove:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow)) emit mouseMoved((QMouseEvent*)event);
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
+                emit mouseMoved((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonPress:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) &&
+                !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseClicked((QMouseEvent *)event);
             break;
         case QEvent::MouseButtonRelease:
-            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) && !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
+            if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow) &&
+                !ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                 emit mouseReleased((QMouseEvent *)event);
             break;
     }

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -14,7 +14,7 @@ if (NOT EXISTS "${IMGUI_ROOT_DIR}/imgui.h")
     endif()
 
     set(IMGUI_REPO "https://github.com/ocornut/imgui.git")
-    set(IMGUI_TAG  "v1.76")
+    set(IMGUI_TAG  "v1.84.1")
     message(STATUS "[INFO] Cloning imgui. Please wait...")
     execute_process(
         COMMAND           ${GIT_EXECUTABLE} clone --recursive --branch ${IMGUI_TAG} ${IMGUI_REPO} ${IMGUI_ROOT_DIR}
@@ -27,6 +27,7 @@ set(IMGUI_SOURCES_CXX_FILES
     ${IMGUI_ROOT_DIR}/imgui.cpp
     ${IMGUI_ROOT_DIR}/imgui_demo.cpp
     ${IMGUI_ROOT_DIR}/imgui_draw.cpp
+    ${IMGUI_ROOT_DIR}/imgui_tables.cpp
     ${IMGUI_ROOT_DIR}/imgui_widgets.cpp
     CACHE STRING ""
 )


### PR DESCRIPTION
This PR updates ImGui submodule to v1.84.1 and required some changes due to API breaking changes and directory structure.

The CMake scripts and Visual Studio solutions have been updated accordingly.

Fixating on version v1.84.1 [instead of v1.84 due to an issue](https://github.com/ocornut/imgui/issues/4452) [noticed](https://github.com/ocornut/imgui/issues/4453) with that release. 